### PR TITLE
chore: heading text alignment fixed in who we are section

### DIFF
--- a/src/app/(root)/components/Home/WhoWeAre/WhoWeAre.tsx
+++ b/src/app/(root)/components/Home/WhoWeAre/WhoWeAre.tsx
@@ -30,14 +30,14 @@ const WhoWeAre = () => {
 
 
     return (
-        <div className='wrapper flex flex-col md:flex-row justify-center gap-10 mt-20'>
+        <div className='wrapper flex flex-col md:flex-row items-center justify-center gap-10 mt-20'>
             {/* who we are image part */}
             <div className='flex-1'>
                 <Image src={wwaImage} className='' alt='Image of who we are section' />
             </div>
             {/* who we are details part start */}
             <div className='flex-1'>
-                <SectionHeading className='text-left items-start py-0 mb-6' heading='We Are Trusted Game Shop' subheading='WHO WE ARE'></SectionHeading>
+                <SectionHeading className='md:text-left md:items-start py-0 mb-6' heading='We Are Trusted Game Shop' subheading='WHO WE ARE'></SectionHeading>
                 <p>A trusted game shop, fueled by our success, passionately dedicated to delivering exceptional gaming experiences through our mission-driven approach.</p>
                 <div className='flex flex-col justify-center items-start gap-3 my-3 md:my-6'>
                     {


### PR DESCRIPTION
## Summary
chore: heading text alignment fixed in who we are section

## Description
chore: heading text alignment fixed in who we are section

## Type
- [ ] **Feature**
- [ ] **Bug Fix**
- [ ] **Documentation**
- [ ] **Refactor**
- [ ] **Test**
- [ ] **Style**
- [x] **Chore**
- [ ] **Other (Specify):**

## Related Issues
N/A

## Screenshots / GIFs (if applicable)
![image](https://github.com/mahmudulturan/gamers-paradise-frontend/assets/97558692/2a1613a9-760e-4e94-90df-aa7cf9f57bed)

## Checklist
- [x] Code follows project style guide
- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests have been added/updated to cover the changes
- [ ] Documentation is updated or added
- [x] No linting errors or warnings
- [x] Follows the [Conventional Commits](https://www.conventionalcommits.org/) standard

## Additional Notes
N/A
